### PR TITLE
Add support for "in:" in Time.at

### DIFF
--- a/rbi/core/time.rbi
+++ b/rbi/core/time.rbi
@@ -211,7 +211,8 @@ class Time < Object
   # ```
   sig do
     params(
-        seconds: T.any(Time, Numeric)
+        seconds: T.any(Time, Numeric),
+        in: T.any(String, Numeric)
     )
     .returns(Time)
   end
@@ -219,6 +220,7 @@ class Time < Object
     params(
         seconds: Numeric,
         microseconds_with_frac: Numeric,
+        in: T.any(String, Numeric),
     )
     .returns(Time)
   end
@@ -230,7 +232,7 @@ class Time < Object
     )
     .returns(Time)
   end
-  def self.at(seconds, microseconds_with_frac=T.unsafe(nil), fractional_precision=T.unsafe(nil)); end
+  def self.at(seconds, microseconds_with_frac=T.unsafe(nil), fractional_precision=T.unsafe(nil), in: T.unsafe(nil)); end
 
   # Creates a [`Time`](https://docs.ruby-lang.org/en/2.7.0/Time.html) object
   # based on given values, interpreted as UTC (GMT). The year must be specified.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Add support for `in:` in Time.at, as per https://ruby-doc.org/core-2.6.3/Time.html#method-c-at

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These should typecheck: https://sorbet.run/#%23%20typed%3A%20true%0Aextend%20T%3A%3ASig%0A%0A%0ATime.at(Time.now%2C%20in%3A%200)%0ATime.at(0%2C%20in%3A%200)%0ATime.at(0%2C%20in%3A%2060%20*%2060%20*%202.5)%0ATime.at(0%2C%20in%3A%20%22-02%3A30%22)%0A%0ATime.at(0%2C%2010000%2C%20in%3A%22-02%3A00%22)%0A%0A

```ruby
Time.at(Time.now, in: 0)
Time.at(0, in: 0)
Time.at(0, in: 60 * 60 * 2.5)
Time.at(0, in: "-02:30")

Time.at(0, 10000, in:"-02:00")
```


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->


```ruby
irb(main):009:0> Time.at(Time.now, in: 0)
=> 2021-03-05 23:57:15.306295 +0000
irb(main):010:0> Time.at(0, in: 0)
=> 1970-01-01 00:00:00 +0000
irb(main):011:0> Time.at(0, in: 60 * 60 * 2.5)
=> 1970-01-01 02:30:00 +0230
irb(main):012:0> Time.at(0, in: "-02:30")
=> 1969-12-31 21:30:00 -0230
irb(main):013:0>
irb(main):014:0> Time.at(0, 10000, in:"-02:00")
=> 1969-12-31 22:00:00.01 -0200
```
